### PR TITLE
replace the `author` field by `authors` in book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,6 @@
 [book]
 title = "Easy Node | Validator Toolbox Manual"
-author = "Easy Node"
+authors = ["Easy Node"]
 description = "Easy Node's User Manual for validatortoolbox Harmony ONE Validator Installer & Management Application"
 language = "en"
 multilingual = false


### PR DESCRIPTION
See the [mdbook documentation](https://rust-lang.github.io/mdBook/format/configuration/general.html)
Apparently the `author` was field was [incorrect documentation](https://github.com/rust-lang/mdBook/issues/2623)